### PR TITLE
修改空链接的效果以防止重复打开当前页面

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -8,7 +8,7 @@
         tag="a"
         target="_blank"
         :style="`color: ${(readedLinks.includes(item.url)) ? 'grey' : 'unset'}`"
-        :href="item.url"
+        :href="item.url || 'javascript:void(0)'"
         :key="item.index"
         @click="clickHandler(item)"
       >


### PR DESCRIPTION
今天的热榜 https://ttop5.net/to-be-slack/#/?id=110 中，第一条的 `href` 为空，然后点击它就会导致重复打开一个当前页面。

![image](https://user-images.githubusercontent.com/20951666/62621210-eeb57300-b94d-11e9-9a80-b9ba7d018a14.png)

![image](https://user-images.githubusercontent.com/20951666/62621259-04c33380-b94e-11e9-8def-515e94654a17.png)
